### PR TITLE
Multiskin support (for 3d_armor 0.5.0)

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -136,12 +136,17 @@ local function change_skin(player)
 	player:set_properties({
 		visual_size = {x=data.width, y=data.height}
 	})
-
-	if minetest.get_modpath("3d_armor") then
-		armor.textures[name].skin = texture
+	if minetest.get_modpath("multiskin") then
+		multiskin.layers[name].skin = texture
 		armor:set_player_armor(player)
-	else
-		player:set_properties({textures={texture}})
+		multiskin:set_player_textures(player,{textures={texture}})
+		else
+			if minetest.get_modpath("3d_armor") then
+			armor.textures[name].skin = texture
+			armor:set_player_armor(player)
+		else
+			player:set_properties({textures={texture}})
+		end
 	end
 
 	-- Save data

--- a/init.lua
+++ b/init.lua
@@ -140,13 +140,11 @@ local function change_skin(player)
 		multiskin.layers[name].skin = texture
 		armor:set_player_armor(player)
 		multiskin:set_player_textures(player,{textures={texture}})
-		else
-			if minetest.get_modpath("3d_armor") then
+		elseif minetest.get_modpath("3d_armor") then
 			armor.textures[name].skin = texture
 			armor:set_player_armor(player)
 		else
 			player:set_properties({textures={texture}})
-		end
 	end
 
 	-- Save data


### PR DESCRIPTION
Retains compatibility for older Minetest releases and older releases of 3d_armor. Added check for multiskin - which is found only in 3d_armor 0.5.0. If multiskin is present, it uses that. Else, it uses 3d_armor or falls back to set_texture