### PR TITLE
Support for skinsdb

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -2,3 +2,4 @@
 multiskin?
 inventory_plus?
 unified_inventory?
+skinsdb?

--- a/init.lua
+++ b/init.lua
@@ -238,6 +238,8 @@ minetest.register_on_joinplayer(function(player)
 		-- set data
 		skin_obj:set_preview("inventory_plus_character_creator.png")
 		skin_obj:set_meta("name","Character Creator")
+		--skin_obj:set_meta("author", "???")
+		skin_obj:set_meta("license", "MIT / CC-BY-SA 3.0 Unported")
 		skin_obj:set_meta("assignment","player:"..playername)
 		skin_obj:set_meta("player", player)
 		--check if active and start the update (avoid race condition for both register_on_joinplayer)


### PR DESCRIPTION
This PR allow to use the character_creator in parallel with [skinsdb](https://github.com/bell07/minetest-skinsdb) simple skins. If skinsdb mod is found the character_creator adds a custom skin trough the skinsdb API at the first place. So the player can select skins in sfinv / smart_inventory or unified_inventory from skinsdb or select the character_creator skin and configure them.
 - some code is moved out to new get_texture(player) from change_skin(player) to be re-usable for skinsdb integration.
- on joinplayer: generate the custom skin assigned to player and apply them if selected.
- If the character_creator was started in other way set custom skin selected...

Remark: skinsdb and 3d_armor supports the skins preview that not supported by character_creator. Therefore the existing icon "inventory_plus_character_creator.png" is used as preview. But this looks strange in 3d_armor selection so maybe a beter preview image is needed.