### PR TITLE
bugfix for #15

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -268,6 +268,14 @@ minetest.register_on_joinplayer(function(player)
 	end
 end)
 
+minetest.register_on_leaveplayer(function(player)
+	if skinsdb then
+		local skinname = "character_creator:"..player:get_player_name()
+		skinsdb.meta[skinname] = nil
+	end
+	skin_indexes[player] = nil
+end)
+
 local skin_temp = {}
 minetest.register_on_player_receive_fields(function(player, formname, fields)
 	if formname ~= "character_creator" then


### PR DESCRIPTION
Each login an custom private skin is registered in skinsdb that needs to be cleaned up on logout.
The issue #15 is timing issue that uses the old skin that does refer to the not existing player object in skin_indexes.
By the way, the skin_indexes[player] needs to be cleaned too.